### PR TITLE
feat: add full auto import logic for typescript >= 5.0.0

### DIFF
--- a/src/5_0/index.ts
+++ b/src/5_0/index.ts
@@ -8,16 +8,16 @@ let projectService: ProjectService;
 export default function (
 	ts: typeof import('typescript/lib/tsserverlibrary'),
 	host: LanguageServiceHost,
-	createLanguageService: (host: LanguageServiceHost) => LanguageService | undefined, 
+	createLanguageService: (host: LanguageServiceHost) => LanguageService | undefined,
 	rootDirectory: string
 ): LanguageService | undefined {
 	// will need to make this the workspace directory
 	if (!projectService) {
 		projectService = createProjectService(
-			ts, 
-			ts.sys, 
+			ts,
+			ts.sys,
 			rootDirectory,
-			{ includePackageJsonAutoImports: PackageJsonAutoImportPreference.On }, 
+			{ includePackageJsonAutoImports: PackageJsonAutoImportPreference.On },
 			ts.LanguageServiceMode.Semantic
 		);
 	}
@@ -36,7 +36,7 @@ export default function (
 
 	// Immediatly invoke so the language service provider is setup
 	// this preinitialises getting auto imports in IDE
-	project.getPackageJsonAutoImportProvider()
+	project.getPackageJsonAutoImportProvider();
 
-	return project.languageService
+	return project.languageService;
 }

--- a/src/5_0/index.ts
+++ b/src/5_0/index.ts
@@ -1,0 +1,44 @@
+import { createProjectService, PackageJsonAutoImportPreference, ProjectService } from './projectService';
+import { createProject } from './project';
+import type { LanguageService, LanguageServiceHost } from 'typescript/lib/tsserverlibrary';
+
+// only create the once for all hosts, as this will improve performance as the internal cache can be reused
+let projectService: ProjectService;
+
+export default function (ts: typeof import('typescript/lib/tsserverlibrary'), host: LanguageServiceHost, service: LanguageService, rootDirectory: string) {
+	// will need to make this the workspace directory
+	if (!projectService) {
+		projectService = createProjectService(
+			ts, 
+			ts.sys, 
+			rootDirectory,
+			{ includePackageJsonAutoImports: PackageJsonAutoImportPreference.On }, 
+			ts.LanguageServiceMode.Semantic
+		);
+	}
+
+	const project = createProject(
+		ts,
+		host,
+		projectService,
+		host.getScriptFileNames(),
+		host.getCurrentDirectory(),
+		host.getCompilationSettings(),
+		service.getProgram(),
+	);
+	project.getPackageJsonAutoImportProvider();
+
+	// @ts-expect-error
+	host.getPackageJsonsVisibleToFile = (fileName: string, rootDir: string | undefined) => project.getPackageJsonsVisibleToFile(fileName, rootDir);
+	// @ts-expect-error
+	host.includePackageJsonAutoImports = () => project.includePackageJsonAutoImports();
+	// @ts-expect-error
+	host.getCachedExportInfoMap = () => project.getCachedExportInfoMap();
+	// @ts-expect-error
+	host.getModuleSpecifierCache = () => project.getModuleSpecifierCache();
+	// @ts-expect-error
+	host.getPackageJsonsForAutoImport = (rootDir: string | undefined) => project.getPackageJsonsForAutoImport(rootDir);
+	// @ts-expect-error
+	host.getPackageJsonAutoImportProvider = () => project.getPackageJsonAutoImportProvider();
+	host.getScriptFileNames = () => project.getScriptFileNames();
+}

--- a/src/5_0/moduleSpecifierCache.ts
+++ b/src/5_0/moduleSpecifierCache.ts
@@ -1,0 +1,127 @@
+import type { Path, UserPreferences, SourceFile } from 'typescript/lib/tsserverlibrary';
+
+export interface ModulePath {
+	path: string;
+	isInNodeModules: boolean;
+	isRedirect: boolean;
+}
+
+export interface ResolvedModuleSpecifierInfo {
+	modulePaths: readonly ModulePath[] | undefined;
+	moduleSpecifiers: readonly string[] | undefined;
+	isBlockedByPackageJsonDependencies: boolean | undefined;
+}
+
+export interface ModuleSpecifierOptions {
+	overrideImportMode?: SourceFile["impliedNodeFormat"];
+}
+
+export interface ModuleSpecifierCache {
+	get(fromFileName: Path, toFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions): Readonly<ResolvedModuleSpecifierInfo> | undefined;
+	set(fromFileName: Path, toFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions, modulePaths: readonly ModulePath[], moduleSpecifiers: readonly string[]): void;
+	setBlockedByPackageJsonDependencies(fromFileName: Path, toFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions, isBlockedByPackageJsonDependencies: boolean): void;
+	setModulePaths(fromFileName: Path, toFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions, modulePaths: readonly ModulePath[]): void;
+	clear(): void;
+	count(): number;
+}
+
+export interface FileWatcher {
+	close(): void;
+}
+
+export interface ModuleSpecifierResolutionCacheHost {
+	watchNodeModulesForPackageJsonChanges(directoryPath: string): FileWatcher;
+}
+
+export const nodeModulesPathPart = "/node_modules/";
+
+export function createModuleSpecifierCache(
+	// host: ModuleSpecifierResolutionCacheHost
+): ModuleSpecifierCache {
+	let containedNodeModulesWatchers: Map<string, FileWatcher> | undefined;
+	let cache: Map<Path, ResolvedModuleSpecifierInfo> | undefined;
+	let currentKey: string | undefined;
+	const result: ModuleSpecifierCache = {
+		get(fromFileName, toFileName, preferences, options) {
+			if (!cache || currentKey !== key(fromFileName, preferences, options)) return undefined;
+			return cache.get(toFileName);
+		},
+		set(fromFileName, toFileName, preferences, options, modulePaths, moduleSpecifiers) {
+			ensureCache(fromFileName, preferences, options).set(toFileName, createInfo(modulePaths, moduleSpecifiers, /*isBlockedByPackageJsonDependencies*/ false));
+
+			// If any module specifiers were generated based off paths in node_modules,
+			// a package.json file in that package was read and is an input to the cached.
+			// Instead of watching each individual package.json file, set up a wildcard
+			// directory watcher for any node_modules referenced and clear the cache when
+			// it sees any changes.
+			if (moduleSpecifiers) {
+				for (const p of modulePaths) {
+					if (p.isInNodeModules) {
+						// No trailing slash
+						// const nodeModulesPath = p.path.substring(0, p.path.indexOf(nodeModulesPathPart) + nodeModulesPathPart.length - 1);
+						// if (!containedNodeModulesWatchers?.has(nodeModulesPath)) {
+						//	 (containedNodeModulesWatchers ||= new Map()).set(
+						//		 nodeModulesPath,
+						//		 host.watchNodeModulesForPackageJsonChanges(nodeModulesPath),
+						//	 );
+						// }
+					}
+				}
+			}
+		},
+		setModulePaths(fromFileName, toFileName, preferences, options, modulePaths) {
+			const cache = ensureCache(fromFileName, preferences, options);
+			const info = cache.get(toFileName);
+			if (info) {
+				info.modulePaths = modulePaths;
+			}
+			else {
+				cache.set(toFileName, createInfo(modulePaths, /*moduleSpecifiers*/ undefined, /*isBlockedByPackageJsonDependencies*/ undefined));
+			}
+		},
+		setBlockedByPackageJsonDependencies(fromFileName, toFileName, preferences, options, isBlockedByPackageJsonDependencies) {
+			const cache = ensureCache(fromFileName, preferences, options);
+			const info = cache.get(toFileName);
+			if (info) {
+				info.isBlockedByPackageJsonDependencies = isBlockedByPackageJsonDependencies;
+			}
+			else {
+				cache.set(toFileName, createInfo(/*modulePaths*/ undefined, /*moduleSpecifiers*/ undefined, isBlockedByPackageJsonDependencies));
+			}
+		},
+		clear() {
+			containedNodeModulesWatchers?.forEach(watcher => watcher.close());
+			cache?.clear();
+			containedNodeModulesWatchers?.clear();
+			currentKey = undefined;
+		},
+		count() {
+			return cache ? cache.size : 0;
+		}
+	};
+	// if (Debug.isDebugging) {
+	//	 Object.defineProperty(result, "__cache", { get: () => cache });
+	// }
+	return result;
+
+	function ensureCache(fromFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions) {
+		const newKey = key(fromFileName, preferences, options);
+		if (cache && (currentKey !== newKey)) {
+			result.clear();
+		}
+		currentKey = newKey;
+		return cache ||= new Map();
+	}
+
+	function key(fromFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions) {
+		return `${fromFileName},${preferences.importModuleSpecifierEnding},${preferences.importModuleSpecifierPreference},${options.overrideImportMode}`;
+	}
+
+	function createInfo(
+		modulePaths: readonly ModulePath[] | undefined,
+		moduleSpecifiers: readonly string[] | undefined,
+		isBlockedByPackageJsonDependencies: boolean | undefined,
+	): ResolvedModuleSpecifierInfo {
+		return { modulePaths, moduleSpecifiers, isBlockedByPackageJsonDependencies };
+	}
+}

--- a/src/5_0/packageJsonCache.ts
+++ b/src/5_0/packageJsonCache.ts
@@ -123,7 +123,7 @@ export function createPackageJsonCache(ts: typeof import('typescript/lib/tsserve
 		return packageJsons.has(combinePaths(directory, 'package.json'))
 			? Ternary.True
 			: directoriesWithoutPackageJson.has(directory)
-			? Ternary.False
-			: Ternary.Maybe;
+				? Ternary.False
+				: Ternary.Maybe;
 	}
 }

--- a/src/5_0/packageJsonCache.ts
+++ b/src/5_0/packageJsonCache.ts
@@ -1,0 +1,129 @@
+import type { Path } from 'typescript/lib/tsserverlibrary';
+import type { ProjectService } from './projectService';
+
+interface PackageJsonPathFields {
+	typings?: string;
+	types?: string;
+	typesVersions?: Map<string, Map<string, string[]>>;
+	main?: string;
+	tsconfig?: string;
+	type?: string;
+	imports?: object;
+	exports?: object;
+	name?: string;
+}
+
+interface VersionPaths {
+	version: string;
+	paths: Map<string, string[]>;
+}
+
+/** @internal */
+export interface PackageJsonInfo {
+	packageDirectory: string;
+	contents: PackageJsonInfoContents;
+}
+/** @internal */
+export interface PackageJsonInfoContents {
+	packageJsonContent: PackageJsonPathFields;
+	/** false: versionPaths are not present. undefined: not yet resolved */
+	versionPaths: VersionPaths | false | undefined;
+	/** false: resolved to nothing. undefined: not yet resolved */
+	resolvedEntrypoints: string[] | false | undefined;
+}
+
+/** @internal */
+export const enum PackageJsonDependencyGroup {
+	Dependencies = 1 << 0,
+	DevDependencies = 1 << 1,
+	PeerDependencies = 1 << 2,
+	OptionalDependencies = 1 << 3,
+	All = Dependencies | DevDependencies | PeerDependencies | OptionalDependencies,
+}
+
+/** @internal */
+export interface ProjectPackageJsonInfo {
+	fileName: string;
+	parseable: boolean;
+	dependencies?: Map<string, string>;
+	devDependencies?: Map<string, string>;
+	peerDependencies?: Map<string, string>;
+	optionalDependencies?: Map<string, string>;
+	get(dependencyName: string, inGroups?: PackageJsonDependencyGroup): string | undefined;
+	has(dependencyName: string, inGroups?: PackageJsonDependencyGroup): boolean;
+}
+export interface ProjectPackageJsonInfo {
+	fileName: string;
+	parseable: boolean;
+	dependencies?: Map<string, string>;
+	devDependencies?: Map<string, string>;
+	peerDependencies?: Map<string, string>;
+	optionalDependencies?: Map<string, string>;
+	get(dependencyName: string, inGroups?: PackageJsonDependencyGroup): string | undefined;
+	has(dependencyName: string, inGroups?: PackageJsonDependencyGroup): boolean;
+}
+
+export interface PackageJsonCache {
+	addOrUpdate(fileName: Path): void;
+	forEach(action: (info: ProjectPackageJsonInfo, fileName: Path) => void): void;
+	delete(fileName: Path): void;
+	get(fileName: Path): ProjectPackageJsonInfo | false | undefined;
+	getInDirectory(directory: Path): ProjectPackageJsonInfo | undefined;
+	directoryHasPackageJson(directory: Path): Ternary;
+	searchDirectoryAndAncestors(directory: Path): void;
+}
+
+export const enum Ternary {
+	False = 0,
+	Unknown = 1,
+	Maybe = 3,
+	True = -1,
+}
+
+export function createPackageJsonCache(ts: typeof import('typescript/lib/tsserverlibrary'), host: ProjectService): PackageJsonCache {
+	const { createPackageJsonInfo, getDirectoryPath, combinePaths, tryFileExists, forEachAncestorDirectory } = ts as any;
+	const packageJsons = new Map<string, ProjectPackageJsonInfo>();
+	const directoriesWithoutPackageJson = new Map<string, true>();
+	return {
+		addOrUpdate,
+		// @ts-expect-error
+		forEach: packageJsons.forEach.bind(packageJsons),
+		get: packageJsons.get.bind(packageJsons),
+		delete: (fileName) => {
+			packageJsons.delete(fileName);
+			directoriesWithoutPackageJson.set(getDirectoryPath(fileName), true);
+		},
+		getInDirectory: (directory) => {
+			return packageJsons.get(combinePaths(directory, 'package.json')) || undefined;
+		},
+		directoryHasPackageJson,
+		searchDirectoryAndAncestors: (directory) => {
+			// @ts-expect-error
+			forEachAncestorDirectory(directory, (ancestor) => {
+				if (directoryHasPackageJson(ancestor) !== Ternary.Maybe) {
+					return true;
+				}
+				const packageJsonFileName = host.toPath(combinePaths(ancestor, 'package.json'));
+				if (tryFileExists(host, packageJsonFileName)) {
+					addOrUpdate(packageJsonFileName);
+				} else {
+					directoriesWithoutPackageJson.set(ancestor, true);
+				}
+			});
+		},
+	};
+
+	function addOrUpdate(fileName: Path) {
+		const packageJsonInfo = /*Debug.checkDefined( */ createPackageJsonInfo(fileName, host.host); /*);*/
+		packageJsons.set(fileName, packageJsonInfo);
+		directoriesWithoutPackageJson.delete(getDirectoryPath(fileName));
+	}
+
+	function directoryHasPackageJson(directory: Path) {
+		return packageJsons.has(combinePaths(directory, 'package.json'))
+			? Ternary.True
+			: directoriesWithoutPackageJson.has(directory)
+			? Ternary.False
+			: Ternary.Maybe;
+	}
+}

--- a/src/5_0/project.ts
+++ b/src/5_0/project.ts
@@ -1,0 +1,450 @@
+import type {
+	CompilerOptions,
+	LanguageServiceHost,
+	Path,
+	Program,
+	ModuleResolutionHost,
+	PerformanceEvent,
+} from 'typescript/lib/tsserverlibrary';
+import type { PackageJsonInfo, ProjectPackageJsonInfo } from './packageJsonCache';
+import { ProjectService, PackageJsonAutoImportPreference } from './projectService';
+import { createModuleSpecifierCache } from './moduleSpecifierCache';
+
+export type Project = ReturnType<typeof createProject>;
+
+type SymlinkCache = any;
+
+export function createProject(
+	ts: typeof import('typescript/lib/tsserverlibrary'),
+	host: LanguageServiceHost,
+	projectService: ProjectService,
+	rootNames: string[],
+	currentDirectory: string,
+	compilerOptions: CompilerOptions,
+	program: Program | undefined,
+) {
+	const {
+		combinePaths,
+		inferredTypesContainingFile,
+		createSymlinkCache,
+		toPath,
+		createCacheableExportInfoMap,
+		timestamp,
+		isInsideNodeModules,
+		LanguageServiceMode
+	} = ts as any;
+	const AutoImportProviderProject = createAutoImportProviderProject(ts, host);
+
+	let projectVersion = host.getProjectVersion?.()
+	function updateProjectIfDirty(project: any) {
+		const newVersion = host.getProjectVersion?.()
+		if (projectVersion === newVersion) return
+		projectVersion = newVersion
+		project.hostProject?.clearCachedExportInfoMap()
+	}
+		
+	return {
+		projectService,
+
+		getCanonicalFileName: projectService.toCanonicalFileName,
+
+		exportMapCache: undefined as undefined | { clear(): void },
+		getCachedExportInfoMap() {
+			return (this.exportMapCache ||= createCacheableExportInfoMap(this));
+		},
+		clearCachedExportInfoMap() {
+			this.exportMapCache?.clear();
+		},
+
+		moduleSpecifierCache: createModuleSpecifierCache(),
+		getModuleSpecifierCache() {
+			return this.moduleSpecifierCache;
+		},
+
+		compilerOptions,
+		getCompilationSettings() {
+			return this.compilerOptions;
+		},
+		getCompilerOptions() {
+			return this.compilerOptions;
+		},
+
+		program,
+		getCurrentProgram(): Program | undefined {
+			return this.program;
+		},
+
+		currentDirectory: projectService.getNormalizedAbsolutePath(currentDirectory || ''),
+		getCurrentDirectory(): string {
+			return this.currentDirectory;
+		},
+
+		symlinks: undefined as SymlinkCache | undefined,
+		getSymlinkCache(): SymlinkCache {
+			if (!this.symlinks) {
+				this.symlinks = createSymlinkCache(this.getCurrentDirectory(), this.getCanonicalFileName);
+			}
+			if (this.program && !this.symlinks.hasProcessedResolutions()) {
+				this.symlinks.setSymlinksFromResolutions(
+					this.program.getSourceFiles(),
+					// @ts-expect-error
+					this.program.getAutomaticTypeDirectiveResolutions(),
+				);
+			}
+			return this.symlinks;
+		},
+
+		packageJsonsForAutoImport: undefined as Set<string> | undefined,
+		getPackageJsonsForAutoImport(rootDir?: string): readonly ProjectPackageJsonInfo[] {
+			const packageJsons = this.getPackageJsonsVisibleToFile(
+				combinePaths(this.currentDirectory, inferredTypesContainingFile),
+				rootDir,
+			);
+			this.packageJsonsForAutoImport = new Set(packageJsons.map((p) => p.fileName));
+			return packageJsons;
+		},
+		getPackageJsonsVisibleToFile(fileName: string, rootDir?: string): readonly ProjectPackageJsonInfo[] {
+			return this.projectService.getPackageJsonsVisibleToFile(fileName, rootDir);
+		},
+
+		rootNames,
+		getScriptFileNames() {
+			return this.rootNames;
+		},
+		getSourceFile(path: Path) {
+			if (!this.program) {
+				return undefined;
+			}
+			return this.program.getSourceFileByPath(path);
+		},
+		isEmpty() {
+			return !this.rootNames.length;
+		},
+
+		getModuleResolutionHostForAutoImportProvider(): ModuleResolutionHost {
+			if (this.program) {
+				return {
+					// @ts-expect-error
+					fileExists: this.program.fileExists,
+					// @ts-expect-error
+					directoryExists: this.program.directoryExists,
+					realpath: undefined,
+					getCurrentDirectory: this.getCurrentDirectory.bind(this),
+					readFile: this.projectService.host.readFile.bind(this.projectService.host),
+					getDirectories: this.projectService.host.getDirectories.bind(this.projectService.host),
+					// trace: this.projectService.host.trace?.bind(this.projectService.host),
+					trace: () => {},
+					// @ts-expect-error
+					useCaseSensitiveFileNames: this.program.useCaseSensitiveFileNames(),
+				};
+			}
+			return this.projectService.host;
+		},
+
+		autoImportProviderHost: undefined as
+			| undefined
+			| false
+			| { getCurrentProgram(): Program | undefined; isEmpty(): boolean; close(): void },
+		getPackageJsonAutoImportProvider(): Program | undefined {
+			if (this.autoImportProviderHost === false) {
+				return undefined;
+			}
+
+			if (this.projectService.serverMode !== LanguageServiceMode.Semantic) {
+				this.autoImportProviderHost = false;
+				return undefined;
+			}
+
+			if (this.autoImportProviderHost) {
+				updateProjectIfDirty(this.autoImportProviderHost);
+				if (this.autoImportProviderHost.isEmpty()) {
+					this.autoImportProviderHost.close();
+					this.autoImportProviderHost = undefined;
+					return undefined;
+				}
+				return this.autoImportProviderHost.getCurrentProgram();
+			}
+
+			const dependencySelection = projectService.includePackageJsonAutoImports();
+			if (dependencySelection) {
+				// tracing?.push(tracing.Phase.Session, "getPackageJsonAutoImportProvider");
+				const start = timestamp();
+				this.autoImportProviderHost = AutoImportProviderProject.create(
+					dependencySelection,
+					this,
+					this.getModuleResolutionHostForAutoImportProvider(),
+				);
+				if (this.autoImportProviderHost) {
+					updateProjectIfDirty(this.autoImportProviderHost);
+					this.sendPerformanceEvent('CreatePackageJsonAutoImportProvider', timestamp() - start);
+					// tracing?.pop();
+					return this.autoImportProviderHost.getCurrentProgram();
+				}
+				// tracing?.pop();
+			}
+		},
+
+		languageServiceEnabled: true,
+		includePackageJsonAutoImports(): PackageJsonAutoImportPreference {
+			if (
+				this.projectService.includePackageJsonAutoImports() === PackageJsonAutoImportPreference.Off ||
+				!this.languageServiceEnabled ||
+				isInsideNodeModules(this.currentDirectory) /* ||
+				!this.isDefaultProjectForOpenFiles()*/
+			) {
+				return PackageJsonAutoImportPreference.Off;
+			}
+			return this.projectService.includePackageJsonAutoImports();
+		},
+
+		close() {},
+		log(_message: string) {},
+		sendPerformanceEvent(_kind: PerformanceEvent['kind'], _durationMs: number) {},
+
+		toPath(fileName: string) {
+			return toPath(fileName, this.currentDirectory, this.projectService.toCanonicalFileName);
+		},
+
+		getCachedDirectoryStructureHost(): undefined {
+			return undefined!; // TODO: GH#18217
+		},
+
+		getGlobalTypingsCacheLocation() {
+			return undefined;
+		},
+	};
+}
+
+function createAutoImportProviderProject(tsBase: typeof import('typescript/lib/tsserverlibrary'), host: LanguageServiceHost) {
+	const ts = tsBase as any
+	const {
+		combinePaths,
+		inferredTypesContainingFile,
+		arrayFrom,
+		resolvePackageNameToPackageJson,
+		concatenate,
+		forEach,
+		startsWith,
+		getEntrypointsFromPackageJsonInfo,
+		mapDefined,
+		timestamp
+	} = ts;
+	return {
+		maxDependencies: 10,
+
+		compilerOptionsOverrides: {
+			diagnostics: false,
+			skipLibCheck: true,
+			sourceMap: false,
+			types: ts.emptyArray,
+			lib: ts.emptyArray,
+			noLib: true,
+		},
+
+		getRootFileNames(
+			dependencySelection: PackageJsonAutoImportPreference,
+			hostProject: Project,
+			moduleResolutionHost: ModuleResolutionHost,
+			compilerOptions: CompilerOptions,
+		): string[] {
+			if (!dependencySelection) {
+				return ts.emptyArray;
+			}
+			const program = hostProject.getCurrentProgram();
+			if (!program) {
+				return ts.emptyArray;
+			}
+
+			const start = timestamp();
+			let dependencyNames: Set<string> | undefined;
+			let rootNames: string[] | undefined;
+			const rootFileName = combinePaths(hostProject.currentDirectory, inferredTypesContainingFile);
+			const packageJsons = hostProject.getPackageJsonsForAutoImport(combinePaths(hostProject.currentDirectory, rootFileName));
+			for (const packageJson of packageJsons) {
+				packageJson.dependencies?.forEach((_, dependenyName) => addDependency(dependenyName));
+				packageJson.peerDependencies?.forEach((_, dependencyName) => addDependency(dependencyName));
+			}
+
+			let dependenciesAdded = 0;
+			if (dependencyNames) {
+				const symlinkCache = hostProject.getSymlinkCache();
+				for (const name of arrayFrom(dependencyNames.keys())) {
+					// Avoid creating a large project that would significantly slow down time to editor interactivity
+					if (dependencySelection === PackageJsonAutoImportPreference.Auto && dependenciesAdded > this.maxDependencies) {
+						hostProject.log(
+							`AutoImportProviderProject: attempted to add more than ${this.maxDependencies} dependencies. Aborting.`,
+						);
+						return ts.emptyArray;
+					}
+
+					// 1. Try to load from the implementation package. For many dependencies, the
+					//	package.json will exist, but the package will not contain any typings,
+					//	so `entrypoints` will be undefined. In that case, or if the dependency
+					//	is missing altogether, we will move on to trying the @types package (2).
+					const packageJson = resolvePackageNameToPackageJson(
+						name,
+						hostProject.currentDirectory,
+						compilerOptions,
+						moduleResolutionHost,
+						// @ts-expect-error
+						program.getModuleResolutionCache(),
+					);
+					if (packageJson) {
+						const entrypoints = getRootNamesFromPackageJson(packageJson, program, symlinkCache);
+						if (entrypoints) {
+							rootNames = concatenate(rootNames, entrypoints);
+							dependenciesAdded += entrypoints.length ? 1 : 0;
+							continue;
+						}
+					}
+
+					// 2. Try to load from the @types package in the tree and in the global
+					//	typings cache location, if enabled.
+					// @ts-expect-error
+					const done = forEach([hostProject.currentDirectory, hostProject.getGlobalTypingsCacheLocation()], (directory) => {
+						if (directory) {
+							const typesPackageJson = resolvePackageNameToPackageJson(
+								`@types/${name}`,
+								directory,
+								compilerOptions,
+								moduleResolutionHost,
+								// @ts-expect-error
+								program.getModuleResolutionCache(),
+							);
+							if (typesPackageJson) {
+								const entrypoints = getRootNamesFromPackageJson(typesPackageJson, program, symlinkCache);
+								rootNames = concatenate(rootNames, entrypoints);
+								dependenciesAdded += entrypoints?.length ? 1 : 0;
+								return true;
+							}
+						}
+					});
+
+					if (done) continue;
+
+					// 3. If the @types package did not exist and the user has settings that
+					//	allow processing JS from node_modules, go back to the implementation
+					//	package and load the JS.
+					if (packageJson && compilerOptions.allowJs && compilerOptions.maxNodeModuleJsDepth) {
+						const entrypoints = getRootNamesFromPackageJson(packageJson, program, symlinkCache, /*allowJs*/ true);
+						rootNames = concatenate(rootNames, entrypoints);
+						dependenciesAdded += entrypoints?.length ? 1 : 0;
+					}
+				}
+			}
+
+			if (rootNames?.length) {
+				hostProject.log(
+					`AutoImportProviderProject: found ${rootNames.length} root files in ${dependenciesAdded} dependencies in ${
+						timestamp() - start
+					} ms`,
+				);
+			}
+			return rootNames || ts.emptyArray;
+
+			function addDependency(dependency: string) {
+				if (!startsWith(dependency, '@types/')) {
+					(dependencyNames || (dependencyNames = new Set())).add(dependency);
+				}
+			}
+
+			function getRootNamesFromPackageJson(
+				packageJson: PackageJsonInfo,
+				program: Program,
+				symlinkCache: SymlinkCache,
+				resolveJs?: boolean,
+			) {
+				const entrypoints = getEntrypointsFromPackageJsonInfo(
+					packageJson,
+					compilerOptions,
+					moduleResolutionHost,
+					// @ts-expect-error
+					program.getModuleResolutionCache(),
+					resolveJs,
+				);
+				if (entrypoints) {
+					const real = moduleResolutionHost.realpath?.(packageJson.packageDirectory);
+					const isSymlink = real && real !== packageJson.packageDirectory;
+					if (isSymlink) {
+						symlinkCache.setSymlinkedDirectory(packageJson.packageDirectory, {
+							real,
+							realPath: hostProject.toPath(real),
+						});
+					}
+
+					// @ts-expect-error
+					return mapDefined(entrypoints, (entrypoint) => {
+						const resolvedFileName = isSymlink ? entrypoint.replace(packageJson.packageDirectory, real) : entrypoint;
+						if (!program.getSourceFile(resolvedFileName) && !(isSymlink && program.getSourceFile(entrypoint))) {
+							return resolvedFileName;
+						}
+					});
+				}
+			}
+		},
+
+		create(dependencySelection: PackageJsonAutoImportPreference, hostProject: Project, moduleResolutionHost: ModuleResolutionHost) {
+			if (dependencySelection === PackageJsonAutoImportPreference.Off) {
+				return undefined;
+			}
+
+			const compilerOptions = {
+				...hostProject.getCompilerOptions(),
+				...this.compilerOptionsOverrides,
+			};
+
+			const rootNames = this.getRootFileNames(dependencySelection, hostProject, moduleResolutionHost, compilerOptions);
+			if (!rootNames.length) {
+				return undefined;
+			}
+
+			return {
+				hostProject,
+				...createProject(
+					tsBase,
+					host,
+					hostProject.projectService,
+					rootNames,
+					hostProject.currentDirectory,
+					compilerOptions,
+					tsBase.createProgram({
+						host: host.getCompilerHost?.(),
+						rootNames,
+						options: compilerOptions,
+						oldProgram: hostProject.program,
+					}),
+				),
+
+				getLanguageService(): never {
+					throw new Error(
+						'AutoImportProviderProject language service should never be used. To get the program, use `project.getCurrentProgram()`.',
+					);
+				},
+
+				/** @internal */
+				onAutoImportProviderSettingsChanged(): never {
+					throw new Error('AutoImportProviderProject is an auto import provider; use `markAsDirty()` instead.');
+				},
+
+				/** @internal */
+				onPackageJsonChange(): never {
+					throw new Error("package.json changes should be notified on an AutoImportProvider's host project");
+				},
+
+				getModuleResolutionHostForAutoImportProvider(): never {
+					throw new Error(
+						'AutoImportProviderProject cannot provide its own host; use `hostProject.getModuleResolutionHostForAutomImportProvider()` instead.',
+					);
+				},
+
+				includePackageJsonAutoImports() {
+					return PackageJsonAutoImportPreference.Off;
+				},
+
+				getSymlinkCache() {
+					return this.hostProject.getSymlinkCache();
+				},
+			};
+		},
+	};
+}

--- a/src/5_0/project.ts
+++ b/src/5_0/project.ts
@@ -5,14 +5,14 @@ import type {
 	Program,
 	ModuleResolutionHost,
 	PerformanceEvent,
-    LanguageService,
+	LanguageService,
 } from 'typescript/lib/tsserverlibrary';
 import type { PackageJsonInfo, ProjectPackageJsonInfo } from './packageJsonCache';
 import { ProjectService, PackageJsonAutoImportPreference } from './projectService';
 import { createModuleSpecifierCache } from './moduleSpecifierCache';
 
 export type Project = ReturnType<typeof createBaseProject>;
-type ProjectOptions = { projectService: ProjectService, compilerOptions: CompilerOptions, currentDirectory: string, rootNames: string[] }
+type ProjectOptions = { projectService: ProjectService, compilerOptions: CompilerOptions, currentDirectory: string, rootNames: string[]; };
 
 type SymlinkCache = any;
 
@@ -23,30 +23,30 @@ export function createProject(
 	options: ProjectOptions,
 	override: Partial<Project> = {}
 ) {
-	const project = createBaseProject(ts, host, createLanguageService, options, override)
+	const project = createBaseProject(ts, host, createLanguageService, options, override);
 	const languageService = createLanguageService(
 		new Proxy(host, {
 			get(target, key: keyof LanguageServiceHost) {
-				return key in project ? (project as any)[key] : target[key]
+				return key in project ? (project as any)[key] : target[key];
 			},
 			set(_target, key, value) {
-				(project as any)[key] = value
-				return true
+				(project as any)[key] = value;
+				return true;
 			}
 		})
-	)
-	project.languageService = languageService
-	project.languageServiceEnabled = !!languageService
-	project.program = languageService?.getProgram()
-	return project
+	);
+	project.languageService = languageService;
+	project.languageServiceEnabled = !!languageService;
+	project.program = languageService?.getProgram();
+	return project;
 }
 
 function createAutoImportProviderProject(
-	tsBase: typeof import('typescript/lib/tsserverlibrary'), 
-	host: LanguageServiceHost, 
+	tsBase: typeof import('typescript/lib/tsserverlibrary'),
+	host: LanguageServiceHost,
 	createLanguageService: (host: LanguageServiceHost) => LanguageService | undefined
 ) {
-	const ts = tsBase as any
+	const ts = tsBase as any;
 	const {
 		combinePaths,
 		inferredTypesContainingFile,
@@ -165,8 +165,7 @@ function createAutoImportProviderProject(
 
 			if (rootNames?.length) {
 				hostProject.log(
-					`AutoImportProviderProject: found ${rootNames.length} root files in ${dependenciesAdded} dependencies in ${
-						timestamp() - start
+					`AutoImportProviderProject: found ${rootNames.length} root files in ${dependenciesAdded} dependencies in ${timestamp() - start
 					} ms`,
 				);
 			}
@@ -245,32 +244,32 @@ function createAutoImportProviderProject(
 							'AutoImportProviderProject language service should never be used. To get the program, use `project.getCurrentProgram()`.',
 						);
 					},
-	
+
 					/** @internal */
 					onAutoImportProviderSettingsChanged(): never {
 						throw new Error('AutoImportProviderProject is an auto import provider; use `markAsDirty()` instead.');
 					},
-	
+
 					/** @internal */
 					onPackageJsonChange(): never {
 						throw new Error("package.json changes should be notified on an AutoImportProvider's host project");
 					},
-	
+
 					getModuleResolutionHostForAutoImportProvider(): never {
 						throw new Error(
 							'AutoImportProviderProject cannot provide its own host; use `hostProject.getModuleResolutionHostForAutomImportProvider()` instead.',
 						);
 					},
-	
+
 					includePackageJsonAutoImports() {
 						return PackageJsonAutoImportPreference.Off;
 					},
-	
+
 					getSymlinkCache() {
 						return hostProject.getSymlinkCache();
 					},
 				}
-			)
+			);
 		}
 	};
 }
@@ -294,17 +293,17 @@ function createBaseProject(
 	} = ts as any;
 	const AutoImportProviderProject = createAutoImportProviderProject(ts, host, createLanguageService);
 
-	const { projectService, compilerOptions, currentDirectory, rootNames } = options
+	const { projectService, compilerOptions, currentDirectory, rootNames } = options;
 
-	let projectVersion = host.getProjectVersion?.()
+	let projectVersion = host.getProjectVersion?.();
 	function updateProjectIfDirty(project: any) {
-		const newVersion = host.getProjectVersion?.()
-		if (projectVersion === newVersion) return
-		projectVersion = newVersion
-		project.hostProject.clearCachedExportInfoMap()
-		project.clearCachedExportInfoMap()
+		const newVersion = host.getProjectVersion?.();
+		if (projectVersion === newVersion) return;
+		projectVersion = newVersion;
+		project.hostProject.clearCachedExportInfoMap();
+		project.clearCachedExportInfoMap();
 	}
-		
+
 	return {
 		hostProject: undefined as any,
 
@@ -312,7 +311,7 @@ function createBaseProject(
 
 		getCanonicalFileName: projectService.toCanonicalFileName,
 
-		exportMapCache: undefined as undefined | { clear(): void },
+		exportMapCache: undefined as undefined | { clear(): void; },
 		getCachedExportInfoMap() {
 			return (this.exportMapCache ||= createCacheableExportInfoMap(this));
 		},
@@ -398,7 +397,7 @@ function createBaseProject(
 					readFile: this.projectService.host.readFile.bind(this.projectService.host),
 					getDirectories: this.projectService.host.getDirectories.bind(this.projectService.host),
 					// trace: this.projectService.host.trace?.bind(this.projectService.host),
-					trace: () => {},
+					trace: () => { },
 					// @ts-expect-error
 					useCaseSensitiveFileNames: this.program.useCaseSensitiveFileNames(),
 				};
@@ -409,7 +408,7 @@ function createBaseProject(
 		autoImportProviderHost: undefined as
 			| undefined
 			| false
-			| { getCurrentProgram(): Program | undefined; isEmpty(): boolean; close(): void },
+			| { getCurrentProgram(): Program | undefined; isEmpty(): boolean; close(): void; },
 		getPackageJsonAutoImportProvider(): Program | undefined {
 			if (this.autoImportProviderHost === false) {
 				return undefined;
@@ -452,7 +451,7 @@ function createBaseProject(
 		languageServiceEnabled: true,
 		languageService: undefined as undefined | LanguageService,
 		getLanguageService() {
-			return this.languageService
+			return this.languageService;
 		},
 
 		includePackageJsonAutoImports(): PackageJsonAutoImportPreference {
@@ -467,9 +466,9 @@ function createBaseProject(
 			return this.projectService.includePackageJsonAutoImports();
 		},
 
-		close() {},
-		log(_message: string) {},
-		sendPerformanceEvent(_kind: PerformanceEvent['kind'], _durationMs: number) {},
+		close() { },
+		log(_message: string) { },
+		sendPerformanceEvent(_kind: PerformanceEvent['kind'], _durationMs: number) { },
 
 		toPath(fileName: string) {
 			return toPath(fileName, this.currentDirectory, this.projectService.toCanonicalFileName);
@@ -484,12 +483,12 @@ function createBaseProject(
 		},
 
 		useSourceOfProjectReferenceRedirect() {
-			return !this.getCompilerOptions().disableSourceOfProjectReferenceRedirect
+			return !this.getCompilerOptions().disableSourceOfProjectReferenceRedirect;
 		},
 
-		onAutoImportProviderSettingsChanged() {},
+		onAutoImportProviderSettingsChanged() { },
 
-		onPackageJsonChange() {},
+		onPackageJsonChange() { },
 
 		...override
 	};

--- a/src/5_0/projectService.ts
+++ b/src/5_0/projectService.ts
@@ -1,4 +1,4 @@
-import type { Path, System, server, LanguageServiceMode } from 'typescript/lib/tsserverlibrary';
+import type { Path, System, server, LanguageServiceMode, UserPreferences } from 'typescript/lib/tsserverlibrary';
 import { createPackageJsonCache, PackageJsonCache, Ternary, ProjectPackageJsonInfo } from './packageJsonCache';
 
 export type ProjectService = ReturnType<typeof createProjectService>;
@@ -15,9 +15,7 @@ export function createProjectService(
 	ts: typeof import('typescript/lib/tsserverlibrary'),
 	host: System,
 	currentDirectory: string,
-	preferences: {
-		includePackageJsonAutoImports: PackageJsonAutoImportPreference;
-	},
+	hostConfiguration: { preferences: UserPreferences; },
 	serverMode: LanguageServiceMode,
 ) {
 	const {
@@ -75,7 +73,11 @@ export function createProjectService(
 		},
 
 		includePackageJsonAutoImports(): PackageJsonAutoImportPreference {
-			return preferences.includePackageJsonAutoImports;
+			switch (hostConfiguration.preferences.includePackageJsonAutoImports) {
+				case 'on': return PackageJsonAutoImportPreference.On;
+				case 'off': return PackageJsonAutoImportPreference.Off;
+				default: return PackageJsonAutoImportPreference.Auto;
+			}
 		},
 
 		fileExists(fileName: NormalizedPath): boolean {

--- a/src/5_0/projectService.ts
+++ b/src/5_0/projectService.ts
@@ -16,7 +16,7 @@ export function createProjectService(
 	host: System,
 	currentDirectory: string,
 	preferences: {
-		includePackageJsonAutoImports: PackageJsonAutoImportPreference
+		includePackageJsonAutoImports: PackageJsonAutoImportPreference;
 	},
 	serverMode: LanguageServiceMode,
 ) {

--- a/src/5_0/projectService.ts
+++ b/src/5_0/projectService.ts
@@ -1,0 +1,88 @@
+import type { Path, System, server, LanguageServiceMode } from 'typescript/lib/tsserverlibrary';
+import { createPackageJsonCache, PackageJsonCache, Ternary, ProjectPackageJsonInfo } from './packageJsonCache';
+
+export type ProjectService = ReturnType<typeof createProjectService>;
+
+type NormalizedPath = server.NormalizedPath;
+
+export const enum PackageJsonAutoImportPreference {
+	Off,
+	On,
+	Auto,
+}
+
+export function createProjectService(
+	ts: typeof import('typescript/lib/tsserverlibrary'),
+	host: System,
+	currentDirectory: string,
+	preferences: {
+		includePackageJsonAutoImports: PackageJsonAutoImportPreference
+	},
+	serverMode: LanguageServiceMode,
+) {
+	const {
+		toPath,
+		getNormalizedAbsolutePath,
+		normalizePath: toNormalizedPath,
+		createGetCanonicalFileName,
+		forEachAncestorDirectory,
+		getDirectoryPath,
+	} = ts as any;
+
+	const projectService = {
+		serverMode,
+		host,
+		currentDirectory: toNormalizedPath(currentDirectory),
+		toCanonicalFileName: createGetCanonicalFileName(host.useCaseSensitiveFileNames),
+		toPath(fileName: string) {
+			return toPath(fileName, this.currentDirectory, this.toCanonicalFileName);
+		},
+
+		getExecutingFilePath() {
+			return this.getNormalizedAbsolutePath(this.host.getExecutingFilePath());
+		},
+
+		getNormalizedAbsolutePath(fileName: string) {
+			return getNormalizedAbsolutePath(fileName, this.host.getCurrentDirectory());
+		},
+
+		packageJsonCache: undefined as unknown as PackageJsonCache,
+		getPackageJsonsVisibleToFile(fileName: string, rootDir?: string): readonly ProjectPackageJsonInfo[] {
+			const packageJsonCache = this.packageJsonCache;
+			const rootPath = rootDir && this.toPath(rootDir);
+			const filePath = this.toPath(fileName);
+			const result: ProjectPackageJsonInfo[] = [];
+			const processDirectory = (directory: Path): boolean | undefined => {
+				switch (packageJsonCache.directoryHasPackageJson(directory)) {
+					// Sync and check same directory again
+					case Ternary.Maybe:
+						packageJsonCache.searchDirectoryAndAncestors(directory);
+						return processDirectory(directory);
+					// Check package.json
+					case Ternary.True:
+						// const packageJsonFileName = _combinePaths(directory, "package.json");
+						// this.watchPackageJsonFile(packageJsonFileName as ts.Path); // TODO
+						const info = packageJsonCache.getInDirectory(directory);
+						if (info) result.push(info as any);
+				}
+				if (rootPath && rootPath === directory) {
+					return true;
+				}
+			};
+
+			forEachAncestorDirectory(getDirectoryPath(filePath), processDirectory);
+			return result;
+		},
+
+		includePackageJsonAutoImports(): PackageJsonAutoImportPreference {
+			return preferences.includePackageJsonAutoImports;
+		},
+
+		fileExists(fileName: NormalizedPath): boolean {
+			return this.host.fileExists(fileName);
+		},
+	};
+
+	projectService.packageJsonCache = createPackageJsonCache(ts, projectService);
+	return projectService;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,29 +5,33 @@ import _44 from './4_4';
 import _47 from './4_7';
 import _50 from './5_0';
 
-export function decorate(
+export function createLanguageService(
 	ts: typeof import('typescript/lib/tsserverlibrary'),
-	host: ts.LanguageServiceHost,
-	service: ts.LanguageService,
+	host: ts.LanguageServiceHost | undefined,
+	createLanguageService: (host: ts.LanguageServiceHost) => ts.LanguageService | undefined,
 	rootDirectory: string
-) {
-
+): ts.LanguageService | undefined {
+	if (!host) return undefined
 	if (semver.gte(ts.version, '5.0.0')) {
-		_50(ts, host, service, rootDirectory);
-		return true;
+		return _50(ts, host, createLanguageService, rootDirectory);
 	} 
 	else if (semver.gte(ts.version, '4.7.0')) {
+		const service = createLanguageService(host)
+		if (!service) return undefined
 		_47(ts, host, service);
-		return true;
+		return service
 	}
 	else if (semver.gte(ts.version, '4.4.0')) {
+		const service = createLanguageService(host)
+		if (!service) return undefined
 		_44(ts, host, service);
-		return true;
+		return service
 	}
 	else if (semver.gte(ts.version, '4.0.0')) {
+		const service = createLanguageService(host)
+		if (!service) return undefined
 		_40(ts, host, service);
-		return true;
+		return service
 	}
-
-	return false;
+	return createLanguageService(host)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,20 @@ import type * as ts from 'typescript/lib/tsserverlibrary';
 import _40 from './4_0';
 import _44 from './4_4';
 import _47 from './4_7';
+import _50 from './5_0';
 
 export function decorate(
 	ts: typeof import('typescript/lib/tsserverlibrary'),
 	host: ts.LanguageServiceHost,
 	service: ts.LanguageService,
+	rootDirectory: string
 ) {
 
-	if (semver.gte(ts.version, '4.7.0')) {
+	if (semver.gte(ts.version, '5.0.0')) {
+		_50(ts, host, service, rootDirectory);
+		return true;
+	} 
+	else if (semver.gte(ts.version, '4.7.0')) {
 		_47(ts, host, service);
 		return true;
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,27 +11,27 @@ export function createLanguageService(
 	createLanguageService: (host: ts.LanguageServiceHost) => ts.LanguageService | undefined,
 	rootDirectory: string
 ): ts.LanguageService | undefined {
-	if (!host) return undefined
+	if (!host) return undefined;
 	if (semver.gte(ts.version, '5.0.0')) {
 		return _50(ts, host, createLanguageService, rootDirectory);
-	} 
+	}
 	else if (semver.gte(ts.version, '4.7.0')) {
-		const service = createLanguageService(host)
-		if (!service) return undefined
+		const service = createLanguageService(host);
+		if (!service) return undefined;
 		_47(ts, host, service);
-		return service
+		return service;
 	}
 	else if (semver.gte(ts.version, '4.4.0')) {
-		const service = createLanguageService(host)
-		if (!service) return undefined
+		const service = createLanguageService(host);
+		if (!service) return undefined;
 		_44(ts, host, service);
-		return service
+		return service;
 	}
 	else if (semver.gte(ts.version, '4.0.0')) {
-		const service = createLanguageService(host)
-		if (!service) return undefined
+		const service = createLanguageService(host);
+		if (!service) return undefined;
 		_40(ts, host, service);
-		return service
+		return service;
 	}
-	return createLanguageService(host)
+	return createLanguageService(host);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,33 +5,34 @@ import _44 from './4_4';
 import _47 from './4_7';
 import _50 from './5_0';
 
+export { PackageJsonAutoImportPreference } from './5_0/projectService';
+
 export function createLanguageService(
 	ts: typeof import('typescript/lib/tsserverlibrary'),
-	host: ts.LanguageServiceHost | undefined,
-	createLanguageService: (host: ts.LanguageServiceHost) => ts.LanguageService | undefined,
-	rootDirectory: string
-): ts.LanguageService | undefined {
-	if (!host) return undefined;
+	host: ts.LanguageServiceHost,
+	createLanguageService: (host: ts.LanguageServiceHost) => ts.LanguageService,
+	rootDirectory: string,
+): {
+	languageService: ts.LanguageService;
+	setPreferences?(preferences: ts.UserPreferences): void;
+} {
 	if (semver.gte(ts.version, '5.0.0')) {
 		return _50(ts, host, createLanguageService, rootDirectory);
 	}
 	else if (semver.gte(ts.version, '4.7.0')) {
 		const service = createLanguageService(host);
-		if (!service) return undefined;
 		_47(ts, host, service);
-		return service;
+		return { languageService: service };
 	}
 	else if (semver.gte(ts.version, '4.4.0')) {
 		const service = createLanguageService(host);
-		if (!service) return undefined;
 		_44(ts, host, service);
-		return service;
+		return { languageService: service };
 	}
 	else if (semver.gte(ts.version, '4.0.0')) {
 		const service = createLanguageService(host);
-		if (!service) return undefined;
 		_40(ts, host, service);
-		return service;
+		return { languageService: service };
 	}
-	return createLanguageService(host);
+	return { languageService: createLanguageService(host) };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
 		"declaration": true,
 		"strict": true,
 		"alwaysStrict": false,
-		"noImplicitUseStrict": true,
 		"resolveJsonModule": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,


### PR DESCRIPTION
Add Project, AutoImportProviderProject and ProjectService objects. The ProjectService instance is used for caching package jsons and sharing cache between all host projects.

The AutoImportProviderProject needs its own program, which will call the AutoImportProviderProject instance as its host.

updateProjectIfDirty function will call updating projects graphs, instead of implementing this complex method which in turn will just invalidate the cached export info map on any changes to the project.

The code is now slightly closer to that of the original implementation.

This should allow setting up project reference redirect support for project reference projects in volar