### PR TITLE
feat: improve auto import provider

### DIFF
--- a/src/5_0/autoImportProviderProject.ts
+++ b/src/5_0/autoImportProviderProject.ts
@@ -1,0 +1,315 @@
+import type { CompilerOptions, LanguageService, LanguageServiceHost, ModuleResolutionHost, Program, TypeAcquisition } from 'typescript/lib/tsserverlibrary';
+import { type Project, createProject } from './project';
+import { PackageJsonAutoImportPreference } from './projectService';
+import type { PackageJsonInfo } from './packageJsonCache';
+import { SymlinkCache } from './symlinkCache';
+
+interface AutoImportProviderProjectOptions {
+	self: ReturnType<typeof createAutoImportProviderProjectStatic>
+	rootNames: string[] | undefined
+	hostProject: Project,
+	compilerOptions: CompilerOptions
+}
+
+export function createAutoImportProviderProjectStatic(
+	tsBase: typeof import('typescript/lib/tsserverlibrary'),
+	host: LanguageServiceHost,
+	createLanguageService: (host: LanguageServiceHost) => LanguageService
+) {
+	const ts = tsBase as any;
+	const {
+		combinePaths,
+		inferredTypesContainingFile,
+		arrayFrom,
+		resolvePackageNameToPackageJson,
+		concatenate,
+		forEach,
+		startsWith,
+		getEntrypointsFromPackageJsonInfo,
+		mapDefined,
+		timestamp,
+	} = ts;
+	return {
+		maxDependencies: 10,
+
+		compilerOptionsOverrides: {
+			diagnostics: false,
+			skipLibCheck: true,
+			sourceMap: false,
+			types: ts.emptyArray,
+			lib: ts.emptyArray,
+			noLib: true,
+		},
+
+		getRootFileNames(
+			dependencySelection: PackageJsonAutoImportPreference,
+			hostProject: Project,
+			moduleResolutionHost: ModuleResolutionHost,
+			compilerOptions: CompilerOptions,
+		): string[] {
+			if (!dependencySelection) {
+				return ts.emptyArray;
+			}
+			const program = hostProject.getCurrentProgram();
+			if (!program) {
+				return ts.emptyArray;
+			}
+
+			const start = timestamp();
+			let dependencyNames: Set<string> | undefined;
+			let rootNames: string[] | undefined;
+			const rootFileName = combinePaths(hostProject.currentDirectory, inferredTypesContainingFile);
+			const packageJsons = hostProject.getPackageJsonsForAutoImport(combinePaths(hostProject.currentDirectory, rootFileName));
+			for (const packageJson of packageJsons) {
+				packageJson.dependencies?.forEach((_, dependenyName) => addDependency(dependenyName));
+				packageJson.peerDependencies?.forEach((_, dependencyName) => addDependency(dependencyName));
+			}
+
+			let dependenciesAdded = 0;
+			if (dependencyNames) {
+				const symlinkCache = hostProject.getSymlinkCache();
+				for (const name of arrayFrom(dependencyNames.keys())) {
+					// Avoid creating a large project that would significantly slow down time to editor interactivity
+					if (dependencySelection === PackageJsonAutoImportPreference.Auto && dependenciesAdded > this.maxDependencies) {
+						hostProject.log(
+							`AutoImportProviderProject: attempted to add more than ${this.maxDependencies} dependencies. Aborting.`,
+						);
+						return ts.emptyArray;
+					}
+
+					// 1. Try to load from the implementation package. For many dependencies, the
+					//	package.json will exist, but the package will not contain any typings,
+					//	so `entrypoints` will be undefined. In that case, or if the dependency
+					//	is missing altogether, we will move on to trying the @types package (2).
+					const packageJson = resolvePackageNameToPackageJson(
+						name,
+						hostProject.currentDirectory,
+						compilerOptions,
+						moduleResolutionHost,
+						// @ts-expect-error
+						program.getModuleResolutionCache(),
+					);
+					if (packageJson) {
+						const entrypoints = getRootNamesFromPackageJson(packageJson, program, symlinkCache);
+						if (entrypoints) {
+							rootNames = concatenate(rootNames, entrypoints);
+							dependenciesAdded += entrypoints.length ? 1 : 0;
+							continue;
+						}
+					}
+
+					// 2. Try to load from the @types package in the tree and in the global
+					//	typings cache location, if enabled.
+					// @ts-expect-error
+					const done = forEach([hostProject.currentDirectory, hostProject.getGlobalTypingsCacheLocation()], (directory) => {
+						if (directory) {
+							const typesPackageJson = resolvePackageNameToPackageJson(
+								`@types/${name}`,
+								directory,
+								compilerOptions,
+								moduleResolutionHost,
+								// @ts-expect-error
+								program.getModuleResolutionCache(),
+							);
+							if (typesPackageJson) {
+								const entrypoints = getRootNamesFromPackageJson(typesPackageJson, program, symlinkCache);
+								rootNames = concatenate(rootNames, entrypoints);
+								dependenciesAdded += entrypoints?.length ? 1 : 0;
+								return true;
+							}
+						}
+					});
+
+					if (done) continue;
+
+					// 3. If the @types package did not exist and the user has settings that
+					//	allow processing JS from node_modules, go back to the implementation
+					//	package and load the JS.
+					if (packageJson && compilerOptions.allowJs && compilerOptions.maxNodeModuleJsDepth) {
+						const entrypoints = getRootNamesFromPackageJson(packageJson, program, symlinkCache, /*allowJs*/ true);
+						rootNames = concatenate(rootNames, entrypoints);
+						dependenciesAdded += entrypoints?.length ? 1 : 0;
+					}
+				}
+			}
+
+			if (rootNames?.length) {
+				hostProject.log(
+					`AutoImportProviderProject: found ${rootNames.length} root files in ${dependenciesAdded} dependencies in ${timestamp() - start
+					} ms`,
+				);
+			}
+			return rootNames || ts.emptyArray;
+
+			function addDependency(dependency: string) {
+				if (!startsWith(dependency, '@types/')) {
+					(dependencyNames || (dependencyNames = new Set())).add(dependency);
+				}
+			}
+
+			function getRootNamesFromPackageJson(
+				packageJson: PackageJsonInfo,
+				program: Program,
+				symlinkCache: SymlinkCache,
+				resolveJs?: boolean,
+			) {
+				const entrypoints = getEntrypointsFromPackageJsonInfo(
+					packageJson,
+					compilerOptions,
+					moduleResolutionHost,
+					// @ts-expect-error
+					program.getModuleResolutionCache(),
+					resolveJs,
+				);
+				if (entrypoints) {
+					const real = moduleResolutionHost.realpath?.(packageJson.packageDirectory);
+					const isSymlink = real && real !== packageJson.packageDirectory;
+					if (isSymlink) {
+						symlinkCache.setSymlinkedDirectory(packageJson.packageDirectory, {
+							real,
+							realPath: hostProject.toPath(real),
+						});
+					}
+
+					// @ts-expect-error
+					return mapDefined(entrypoints, (entrypoint) => {
+						const resolvedFileName = isSymlink ? entrypoint.replace(packageJson.packageDirectory, real) : entrypoint;
+						if (!program.getSourceFile(resolvedFileName) && !(isSymlink && program.getSourceFile(entrypoint))) {
+							return resolvedFileName;
+						}
+					});
+				}
+			}
+		},
+
+		create(dependencySelection: PackageJsonAutoImportPreference, hostProject: Project, moduleResolutionHost: ModuleResolutionHost) {
+			if (dependencySelection === PackageJsonAutoImportPreference.Off) {
+				return undefined;
+			}
+
+			const compilerOptions = {
+				...hostProject.getCompilerOptions(),
+				...this.compilerOptionsOverrides,
+			};
+
+			let rootNames: string[] | undefined = this.getRootFileNames(dependencySelection, hostProject, moduleResolutionHost, compilerOptions);
+			if (!rootNames.length) {
+				return undefined;
+			}
+
+			return createAutoImportProviderProject(tsBase, host, createLanguageService, { self: this, hostProject, rootNames, compilerOptions })
+		}	
+	};
+}
+
+function createAutoImportProviderProject(
+	tsBase: typeof import('typescript/lib/tsserverlibrary'),
+	host: LanguageServiceHost,
+	createLanguageService: (host: LanguageServiceHost) => LanguageService,
+	options: AutoImportProviderProjectOptions
+) {
+	const { self, rootNames, compilerOptions, hostProject } = options
+	const ts = tsBase as any;
+	const { some } = ts;
+
+	return {
+		...createProject(
+			tsBase,
+			host,
+			createLanguageService,
+			{
+				projectService: hostProject.projectService,
+				rootNames,
+				currentDirectory: hostProject.currentDirectory,
+				compilerOptions,
+			}
+		),
+
+		rootFileNames: rootNames as undefined | string[],
+
+		hostProject,
+
+		isEmpty() {
+			return !some(this.rootFileNames);
+		},
+	
+		isOrphan() {
+			return true;
+		},
+	
+		updateGraph() {
+			let rootFileNames = this.rootFileNames;
+			if (!rootFileNames) {
+				rootFileNames = self.getRootFileNames(
+					this.hostProject.includePackageJsonAutoImports(),
+					this.hostProject,
+					this.hostProject.getModuleResolutionHostForAutoImportProvider(),
+					this.getCompilationSettings());
+			}
+			this.rootFileNames = rootFileNames;
+			const oldProgram = this.getCurrentProgram();
+			this.program = this.languageService?.getProgram(); 
+			this.dirty = false;
+			if (oldProgram && oldProgram !== this.getCurrentProgram()) {
+				this.hostProject.clearCachedExportInfoMap();
+			}
+		},
+
+		scheduleInvalidateResolutionsOfFailedLookupLocations(): void {
+			// Invalidation will happen on-demand as part of updateGraph
+			return;
+		},
+	
+		hasRoots() {
+			return !!this.rootFileNames?.length;
+		},
+	
+		markAsDirty() {
+			if (!this.dirty) {
+				this.rootFileNames = undefined;
+				this.dirty = true;
+			}
+		},
+	
+		getScriptFileNames() {
+			return this.rootFileNames || ts.emptyArray;
+		},
+	
+		getLanguageService(): never {
+			throw new Error("AutoImportProviderProject language service should never be used. To get the program, use `project.getCurrentProgram()`.");
+		},
+	
+		onAutoImportProviderSettingsChanged(): never {
+			throw new Error("AutoImportProviderProject is an auto import provider; use `markAsDirty()` instead.");
+		},
+	
+		onPackageJsonChange(): never {
+			throw new Error("package.json changes should be notified on an AutoImportProvider's host project");
+		},
+	
+		getModuleResolutionHostForAutoImportProvider(): never {
+			throw new Error("AutoImportProviderProject cannot provide its own host; use `hostProject.getModuleResolutionHostForAutomImportProvider()` instead.");
+		},
+	
+		getProjectReferences() {
+			return this.hostProject.getProjectReferences();
+		},
+	
+		includePackageJsonAutoImports() {
+			return PackageJsonAutoImportPreference.Off;
+		},
+	
+		getTypeAcquisition(): TypeAcquisition {
+			return { enable: false };
+		},
+	
+		getSymlinkCache() {
+			return this.hostProject.getSymlinkCache();
+		},
+
+		getModuleResolutionCache() {
+			// @ts-expect-error
+			return this.hostProject.getCurrentProgram()?.getModuleResolutionCache();
+		},
+	}
+}

--- a/src/5_0/autoImportProviderProject.ts
+++ b/src/5_0/autoImportProviderProject.ts
@@ -219,7 +219,6 @@ function createAutoImportProviderProject(
 			createLanguageService,
 			{
 				projectService: hostProject.projectService,
-				rootNames,
 				currentDirectory: hostProject.currentDirectory,
 				compilerOptions,
 			}
@@ -305,7 +304,7 @@ function createAutoImportProviderProject(
 
 		getModuleResolutionCache() {
 			// @ts-expect-error
-			return this.hostProject.getCurrentProgram()?.getModuleResolutionCache();
+			return this.hostProject.languageService?.getProgram()?.getModuleResolutionCache();
 		},
 	}
 

--- a/src/5_0/exportInfoMap.ts
+++ b/src/5_0/exportInfoMap.ts
@@ -1,0 +1,31 @@
+import type { Path, __String, SourceFile, TypeChecker, Symbol, SymbolFlags } from "typescript/lib/tsserverlibrary";
+
+export const enum ExportKind {
+    Named,
+    Default,
+    ExportEquals,
+    UMD,
+}
+
+export interface SymbolExportInfo {
+    readonly symbol: Symbol;
+    readonly moduleSymbol: Symbol;
+    /** Set if `moduleSymbol` is an external module, not an ambient module */
+    moduleFileName: string | undefined;
+    exportKind: ExportKind;
+    targetFlags: SymbolFlags;
+    /** True if export was only found via the package.json AutoImportProvider (for telemetry). */
+    isFromPackageJson: boolean;
+}
+
+export interface ExportInfoMap {
+    isUsableByFile(importingFile: Path): boolean;
+    clear(): void;
+    add(importingFile: Path, symbol: Symbol, key: __String, moduleSymbol: Symbol, moduleFile: SourceFile | undefined, exportKind: ExportKind, isFromPackageJson: boolean, checker: TypeChecker): void;
+    get(importingFile: Path, key: string): readonly SymbolExportInfo[] | undefined;
+    search<T>(importingFile: Path, preferCapitalized: boolean, matches: (name: string, targetFlags: SymbolFlags) => boolean, action: (info: readonly SymbolExportInfo[], symbolName: string, isFromAmbientModule: boolean, key: string) => T | undefined): T | undefined;
+    releaseSymbols(): void;
+    isEmpty(): boolean;
+    /** @returns Whether the change resulted in the cache being cleared */
+    onFileChanged(oldSourceFile: SourceFile, newSourceFile: SourceFile, typeAcquisitionEnabled: boolean): boolean;
+}

--- a/src/5_0/index.ts
+++ b/src/5_0/index.ts
@@ -30,7 +30,6 @@ export default function (
 		createLanguageService,
 		{
 			projectService,
-			rootNames: host.getScriptFileNames(),
 			currentDirectory: host.getCurrentDirectory(),
 			compilerOptions: host.getCompilationSettings(),
 		}
@@ -44,8 +43,7 @@ export default function (
 		'getPackageJsonsVisibleToFile',
 		'getPackageJsonAutoImportProvider',
 		'includePackageJsonAutoImports',
-		'useSourceOfProjectReferenceRedirect',
-		'log',
+		'useSourceOfProjectReferenceRedirect'
 	]
 	proxyMethods.forEach(key => (host as any)[key] = project[key].bind(project))
 	initProject(project, host, createLanguageService)

--- a/src/5_0/index.ts
+++ b/src/5_0/index.ts
@@ -1,9 +1,10 @@
 import { createProjectService, ProjectService } from './projectService';
-import { createProject } from './project';
+import { createProject, Project } from './project';
 import type { LanguageService, LanguageServiceHost, UserPreferences } from 'typescript/lib/tsserverlibrary';
 
 // only create the once for all hosts, as this will improve performance as the internal cache can be reused
 let projectService: ProjectService;
+const projects = new Set<Project>()
 
 export default function (
 	ts: typeof import('typescript/lib/tsserverlibrary'),
@@ -13,7 +14,6 @@ export default function (
 ) {
 	const hostConfiguration = { preferences: { includePackageJsonAutoImports: 'auto' } as UserPreferences };
 
-	// will need to make this the workspace directory
 	if (!projectService) {
 		projectService = createProjectService(
 			ts,
@@ -39,6 +39,7 @@ export default function (
 	// Immediatly invoke so the language service provider is setup
 	// this preinitialises getting auto imports in IDE
 	project.getPackageJsonAutoImportProvider();
+	projects.add(project)
 
 	return {
 		languageService: project.languageService!,
@@ -48,6 +49,18 @@ export default function (
 			if (onAutoImportProviderSettingsChanged) {
 				project.onAutoImportProviderSettingsChanged();
 			}
+		},
+		projectUpdated(path: string) {
+			projects.forEach(projectToUpdate => {
+				if (project === projectToUpdate || !projectToUpdate.autoImportProviderHost) return
+
+				const realPaths = [...projectToUpdate.symlinks?.getSymlinkedDirectoriesByRealpath()?.keys() ?? []]
+					.map(name => projectToUpdate.projectService.getNormalizedAbsolutePath(name));
+				
+				if (realPaths.includes(projectToUpdate.projectService.toCanonicalFileName(path))) {
+					projectToUpdate.autoImportProviderHost.markAsDirty();
+				}
+			})
 		},
 	};
 }

--- a/src/5_0/project.ts
+++ b/src/5_0/project.ts
@@ -33,7 +33,7 @@ export function createProject(
 	const languageService = createLanguageService(
 		new Proxy(host, {
 			get(target, key: keyof LanguageServiceHost) {
-				return key in target ? target[key] : (project as any)[key];
+				return target[key] ?? (project as any)[key];
 			},
 			set(_target, key, value) {
 				(project as any)[key] = value;

--- a/src/5_0/symlinkCache.ts
+++ b/src/5_0/symlinkCache.ts
@@ -1,0 +1,45 @@
+import type { ModeAwareCache, Path, ResolvedTypeReferenceDirectiveWithFailedLookupLocations, SourceFile } from "typescript/lib/tsserverlibrary";
+
+export interface MultiMap<K, V> extends Map<K, V[]> {
+    /**
+     * Adds the value to an array of values associated with the key, and returns the array.
+     * Creates the array if it does not already exist.
+     */
+    add(key: K, value: V): V[];
+    /**
+     * Removes a value from an array of values associated with the key.
+     * Does not preserve the order of those values.
+     * Does nothing if `key` is not in `map`, or `value` is not in `map[key]`.
+     */
+    remove(key: K, value: V): void;
+}
+
+export interface SymlinkedDirectory {
+    /** Matches the casing returned by `realpath`.  Used to compute the `realpath` of children. */
+    real: string;
+    /** toPath(real).  Stored to avoid repeated recomputation. */
+    realPath: Path;
+}
+
+export interface SymlinkCache {
+    /** Gets a map from symlink to realpath. Keys have trailing directory separators. */
+    getSymlinkedDirectories(): ReadonlyMap<Path, SymlinkedDirectory | false> | undefined;
+    /** Gets a map from realpath to symlinks. Keys have trailing directory separators. */
+    getSymlinkedDirectoriesByRealpath(): MultiMap<Path, string> | undefined;
+    /** Gets a map from symlink to realpath */
+    getSymlinkedFiles(): ReadonlyMap<Path, string> | undefined;
+    setSymlinkedDirectory(symlink: string, real: SymlinkedDirectory | false): void;
+    setSymlinkedFile(symlinkPath: Path, real: string): void;
+    /**
+     * @internal
+     * Uses resolvedTypeReferenceDirectives from program instead of from files, since files
+     * don't include automatic type reference directives. Must be called only when
+     * `hasProcessedResolutions` returns false (once per cache instance).
+     */
+    setSymlinksFromResolutions(files: readonly SourceFile[], typeReferenceDirectives: ModeAwareCache<ResolvedTypeReferenceDirectiveWithFailedLookupLocations>): void;
+    /**
+     * @internal
+     * Whether `setSymlinksFromResolutions` has already been called.
+     */
+    hasProcessedResolutions(): boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export function createLanguageService(
 ): {
 	languageService: ts.LanguageService;
 	setPreferences?(preferences: ts.UserPreferences): void;
+	projectUpdated?(updatedProjectDirectory: string): void;
 } {
 	if (semver.gte(ts.version, '5.0.0')) {
 		return _50(ts, host, createLanguageService, rootDirectory);


### PR DESCRIPTION
Ensure that auto import provider only clears cache when referencing symlink has changed, previously it would reset the cache when any changes to projects where made. This could be slow to pick up auto imports as it would trigger auto import
to resolve every time change was made.

Copy more source types over from source to make the code more typesafe and easier to reason with.

Decouple auto import provider project to separate file to make easier to work with.