### PR TITLE
fix: compatible with TS 5.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,44 +1,49 @@
-lockfileVersion: 5.4
+lockfileVersion: '6.0'
 
-specifiers:
-  '@types/semver': ^7.3.13
-  semver: ^7.3.8
-  typescript: latest
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
-  semver: 7.3.8
+  semver:
+    specifier: ^7.3.8
+    version: 7.5.4
 
 devDependencies:
-  '@types/semver': 7.3.13
-  typescript: 4.9.5
+  '@types/semver':
+    specifier: ^7.3.13
+    version: 7.5.6
+  typescript:
+    specifier: latest
+    version: 5.3.3
 
 packages:
 
-  /@types/semver/7.3.13:
-    resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
+  /@types/semver@7.5.6:
+    resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
     dev: true
 
-  /lru-cache/6.0.0:
+  /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
     dev: false
 
-  /semver/7.3.8:
-    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
+  /semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
     dev: false
 
-  /typescript/4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
     hasBin: true
     dev: true
 
-  /yallist/4.0.0:
+  /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: false

--- a/src/5_0/index.ts
+++ b/src/5_0/index.ts
@@ -10,7 +10,8 @@ export default function (
 	ts: typeof import('typescript/lib/tsserverlibrary'),
 	sys: import('typescript/lib/tsserverlibrary').System,
 	host: LanguageServiceHost,
-	createLanguageService: (host: LanguageServiceHost) => LanguageService
+	createLanguageService: (host: LanguageServiceHost) => LanguageService,
+	_createProject: typeof createProject = createProject
 ) {
 	const hostConfiguration = { preferences: { includePackageJsonAutoImports: 'auto' } as UserPreferences };
 
@@ -24,7 +25,7 @@ export default function (
 		);
 	}
 
-	const project = createProject(
+	const project = _createProject(
 		ts,
 		host,
 		createLanguageService,

--- a/src/5_0/project.ts
+++ b/src/5_0/project.ts
@@ -14,7 +14,7 @@ import { SymlinkCache } from './symlinkCache';
 import { ExportInfoMap } from './exportInfoMap';
 
 export type Project = ReturnType<typeof createProject>;
-interface ProjectOptions { 
+export interface ProjectOptions { 
 	projectService: ProjectService;
 	compilerOptions: CompilerOptions;
 	currentDirectory: string;

--- a/src/5_3/index.ts
+++ b/src/5_3/index.ts
@@ -1,0 +1,12 @@
+import type { LanguageService, LanguageServiceHost } from 'typescript/lib/tsserverlibrary';
+import _50 from '../5_0';
+import { createProject } from './project';
+
+export default function (
+	ts: typeof import('typescript/lib/tsserverlibrary'),
+	sys: import('typescript/lib/tsserverlibrary').System,
+	host: LanguageServiceHost,
+	createLanguageService: (host: LanguageServiceHost) => LanguageService
+) {
+	return _50(ts, sys, host, createLanguageService, createProject);
+}

--- a/src/5_3/project.ts
+++ b/src/5_3/project.ts
@@ -1,0 +1,30 @@
+import type { LanguageService, LanguageServiceHost } from 'typescript/lib/tsserverlibrary';
+import { ProjectOptions, createProject as _createProject } from '../5_0/project';
+import { SymlinkCache } from './symlinkCache';
+
+export function createProject(
+	ts: typeof import('typescript/lib/tsserverlibrary'),
+	host: LanguageServiceHost,
+	createLanguageService: (host: LanguageServiceHost) => LanguageService,
+	options: ProjectOptions
+) {
+	const { createSymlinkCache } = ts as any;
+	const project = _createProject(ts, host, createLanguageService, options);
+	project.getSymlinkCache = () => {
+		if (!project.symlinks) {
+			project.symlinks = createSymlinkCache(project.getCurrentDirectory(), project.getCanonicalFileName);
+		}
+		if (project.program && !(project.symlinks as unknown as SymlinkCache).hasProcessedResolutions()) {
+			(project.symlinks as unknown as SymlinkCache).setSymlinksFromResolutions(
+				// @ts-expect-error
+				project.program.forEachResolvedModule,
+				// @ts-expect-error
+				project.program.forEachResolvedTypeReferenceDirective,
+				// @ts-expect-error
+				project.program.getAutomaticTypeDirectiveResolutions(),
+			);
+		}
+		return project.symlinks!;
+	};
+	return project;
+}

--- a/src/5_3/symlinkCache.ts
+++ b/src/5_3/symlinkCache.ts
@@ -1,0 +1,33 @@
+import type { MultiMap, SymlinkedDirectory } from "../5_0/symlinkCache";
+import type { ModeAwareCache, Path, ResolutionMode, ResolvedModuleWithFailedLookupLocations, ResolvedTypeReferenceDirectiveWithFailedLookupLocations } from "typescript/lib/tsserverlibrary";
+
+export interface SymlinkCache {
+    /** Gets a map from symlink to realpath. Keys have trailing directory separators. */
+    getSymlinkedDirectories(): ReadonlyMap<Path, SymlinkedDirectory | false> | undefined;
+    /** Gets a map from realpath to symlinks. Keys have trailing directory separators. */
+    getSymlinkedDirectoriesByRealpath(): MultiMap<Path, string> | undefined;
+    /** Gets a map from symlink to realpath */
+    getSymlinkedFiles(): ReadonlyMap<Path, string> | undefined;
+    setSymlinkedDirectory(symlink: string, real: SymlinkedDirectory | false): void;
+    setSymlinkedFile(symlinkPath: Path, real: string): void;
+    /**
+     * @internal
+     * Uses resolvedTypeReferenceDirectives from program instead of from files, since files
+     * don't include automatic type reference directives. Must be called only when
+     * `hasProcessedResolutions` returns false (once per cache instance).
+     */
+    setSymlinksFromResolutions(
+        forEachResolvedModule: (
+            callback: (resolution: ResolvedModuleWithFailedLookupLocations, moduleName: string, mode: ResolutionMode, filePath: Path) => void,
+        ) => void,
+        forEachResolvedTypeReferenceDirective: (
+            callback: (resolution: ResolvedTypeReferenceDirectiveWithFailedLookupLocations, moduleName: string, mode: ResolutionMode, filePath: Path) => void,
+        ) => void,
+        typeReferenceDirectives: ModeAwareCache<ResolvedTypeReferenceDirectiveWithFailedLookupLocations>,
+    ): void;
+    /**
+     * @internal
+     * Whether `setSymlinksFromResolutions` has already been called.
+     */
+    hasProcessedResolutions(): boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import _40 from './4_0';
 import _44 from './4_4';
 import _47 from './4_7';
 import _50 from './5_0';
+import _53 from './5_3';
 
 export { PackageJsonAutoImportPreference } from './5_0/projectService';
 
@@ -17,7 +18,10 @@ export function createLanguageService(
 	setPreferences?(preferences: ts.UserPreferences): void;
 	projectUpdated?(updatedProjectDirectory: string): void;
 } {
-	if (semver.gte(ts.version, '5.0.0')) {
+	if (semver.gte(ts.version, '5.3.0')) {
+		return _53(ts, sys, host, createLanguageService);
+	}
+	else if (semver.gte(ts.version, '5.0.0')) {
 		return _50(ts, sys, host, createLanguageService);
 	}
 	else if (semver.gte(ts.version, '4.7.0')) {


### PR DESCRIPTION
fix https://github.com/vuejs/language-tools/issues/3802

TS 5.3 changed the `SymlinkCache` interface causing the language server to throw.