### PR TITLE
fix some issue with package.json auto import

### DIFF
--- a/src/5_0/autoImportProviderProject.ts
+++ b/src/5_0/autoImportProviderProject.ts
@@ -224,6 +224,11 @@ function createAutoImportProviderProject(
 			}
 		),
 
+		projectVersion: 0,
+		getProjectVersion() {
+			return this.projectVersion.toString();
+		},
+
 		rootFileNames: rootNames as undefined | string[],
 
 		hostProject,
@@ -266,6 +271,7 @@ function createAutoImportProviderProject(
 		markAsDirty() {
 			if (!this.dirty) {
 				this.rootFileNames = undefined;
+				this.projectVersion++;
 				this.dirty = true;
 			}
 		},


### PR DESCRIPTION
Fixes two issues with the package.json auto import. The first is the project version. Currently, this is proxying the project version of the main project's language service host. So, the synchronizeHostData will skip the update unless the main project also gets updated at the same time. 

The second issue is with the `setSymlinkedDirectory`. TypeScript 5.3 changes this to always need a trailing directory separator. I only patched it for 5.3. Because in 5.0, there are still places where it doesn't have the trailing directory separator. 