### PR TITLE
fix: compatible with TS 5.6

### DIFF
--- a/src/5_0/project.ts
+++ b/src/5_0/project.ts
@@ -37,6 +37,12 @@ export function createProject(
 		isInsideNodeModules,
 		LanguageServiceMode,
 	} = ts as any;
+
+	const tsCreateModuleSpecifierCache = (ts.server as any)?.createModuleSpecifierCache;
+	const noopHost = {
+		watchNodeModulesForPackageJsonChanges: () => ({ close: () => { } }),
+		toPath
+	}
 	const AutoImportProviderProject = createAutoImportProviderProjectStatic(ts, host, createLanguageService);
 
 	const { projectService, compilerOptions, currentDirectory } = options;
@@ -61,7 +67,9 @@ export function createProject(
 			this.exportMapCache?.clear();
 		},
 
-		moduleSpecifierCache: (options.createModuleSpecifierCache ?? createModuleSpecifierCache)(),
+		moduleSpecifierCache: tsCreateModuleSpecifierCache 
+			? tsCreateModuleSpecifierCache(noopHost)
+			: (options.createModuleSpecifierCache ?? createModuleSpecifierCache)(),
 		getModuleSpecifierCache() {
 			return this.moduleSpecifierCache;
 		},

--- a/src/5_6/index.ts
+++ b/src/5_6/index.ts
@@ -1,0 +1,12 @@
+import type { LanguageService, LanguageServiceHost } from 'typescript/lib/tsserverlibrary';
+import _50 from '../5_0';
+import { createProject } from './project';
+
+export default function (
+	ts: typeof import('typescript/lib/tsserverlibrary'),
+	sys: import('typescript/lib/tsserverlibrary').System,
+	host: LanguageServiceHost,
+	createLanguageService: (host: LanguageServiceHost) => LanguageService
+) {
+	return _50(ts, sys, host, createLanguageService, createProject);
+}

--- a/src/5_6/moduleSpecifierCache.ts
+++ b/src/5_6/moduleSpecifierCache.ts
@@ -1,0 +1,114 @@
+import type { FileWatcher, Path, UserPreferences } from 'typescript/lib/tsserverlibrary';
+import { ModulePath, ModuleSpecifierOptions } from '../5_0/moduleSpecifierCache';
+
+export interface ResolvedModuleSpecifierInfo {
+	kind: "node_modules" | "paths" | "redirect" | "relative" | "ambient" | undefined;
+	modulePaths: readonly ModulePath[] | undefined;
+    packageName: string | undefined;
+	moduleSpecifiers: readonly string[] | undefined;
+	isBlockedByPackageJsonDependencies: boolean | undefined;
+}
+
+export interface ModuleSpecifierCache {
+    get(fromFileName: Path, toFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions): Readonly<ResolvedModuleSpecifierInfo> | undefined;
+    set(fromFileName: Path, toFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions, kind: ResolvedModuleSpecifierInfo["kind"], modulePaths: readonly ModulePath[], moduleSpecifiers: readonly string[]): void;
+    setBlockedByPackageJsonDependencies(fromFileName: Path, toFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions, packageName: string | undefined, isBlockedByPackageJsonDependencies: boolean): void;
+    setModulePaths(fromFileName: Path, toFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions, modulePaths: readonly ModulePath[]): void;
+    clear(): void;
+    count(): number;
+}
+
+export function createModuleSpecifierCache(
+	// host: ModuleSpecifierResolutionCacheHost
+): ModuleSpecifierCache {
+	let containedNodeModulesWatchers: Map<string, FileWatcher> | undefined;
+	let cache: Map<Path, ResolvedModuleSpecifierInfo> | undefined;
+	let currentKey: string | undefined;
+	const result: ModuleSpecifierCache = {
+		get(fromFileName, toFileName, preferences, options) {
+			if (!cache || currentKey !== key(fromFileName, preferences, options)) return undefined;
+			return cache.get(toFileName);
+		},
+		set(fromFileName, toFileName, preferences, options, kind, modulePaths, moduleSpecifiers) {
+			ensureCache(fromFileName, preferences, options).set(toFileName, createInfo(kind, modulePaths, moduleSpecifiers, /*packageName */undefined, /*isBlockedByPackageJsonDependencies*/ false));
+
+			// If any module specifiers were generated based off paths in node_modules,
+			// a package.json file in that package was read and is an input to the cached.
+			// Instead of watching each individual package.json file, set up a wildcard
+			// directory watcher for any node_modules referenced and clear the cache when
+			// it sees any changes.
+			if (moduleSpecifiers) {
+				for (const p of modulePaths) {
+					if (p.isInNodeModules) {
+						// No trailing slash
+						// const nodeModulesPath = p.path.substring(0, p.path.indexOf(nodeModulesPathPart) + nodeModulesPathPart.length - 1);
+						// const key = host.toPath(nodeModulesPath);
+						// if (!containedNodeModulesWatchers?.has(key)) {
+						//	 (containedNodeModulesWatchers ||= new Map()).set(
+						//		 key,
+						//		 host.watchNodeModulesForPackageJsonChanges(nodeModulesPath),
+						//	 );
+						// }
+					}
+				}
+			}
+		},
+		setModulePaths(fromFileName, toFileName, preferences, options, modulePaths) {
+			const cache = ensureCache(fromFileName, preferences, options);
+			const info = cache.get(toFileName);
+			if (info) {
+				info.modulePaths = modulePaths;
+			}
+			else {
+				cache.set(toFileName, createInfo(/*kind*/ undefined, modulePaths, /*moduleSpecifiers*/ undefined, /*packageName */undefined,/*isBlockedByPackageJsonDependencies*/ undefined));
+			}
+		},
+		setBlockedByPackageJsonDependencies(fromFileName, toFileName, preferences, options, packageName, isBlockedByPackageJsonDependencies) {
+			const cache = ensureCache(fromFileName, preferences, options);
+			const info = cache.get(toFileName);
+			if (info) {
+				info.isBlockedByPackageJsonDependencies = isBlockedByPackageJsonDependencies;
+                info.packageName = packageName;
+			}
+			else {
+				cache.set(toFileName, createInfo(/*kind*/ undefined, /*modulePaths*/ undefined, /*moduleSpecifiers*/ undefined, /*packageName */undefined, isBlockedByPackageJsonDependencies));
+			}
+		},
+		clear() {
+			containedNodeModulesWatchers?.forEach(watcher => watcher.close());
+			cache?.clear();
+			containedNodeModulesWatchers?.clear();
+			currentKey = undefined;
+		},
+		count() {
+			return cache ? cache.size : 0;
+		}
+	};
+	// if (Debug.isDebugging) {
+	//	 Object.defineProperty(result, "__cache", { get: () => cache });
+	// }
+	return result;
+
+	function ensureCache(fromFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions) {
+		const newKey = key(fromFileName, preferences, options);
+		if (cache && (currentKey !== newKey)) {
+			result.clear();
+		}
+		currentKey = newKey;
+		return cache ||= new Map();
+	}
+
+	function key(fromFileName: Path, preferences: UserPreferences, options: ModuleSpecifierOptions) {
+		return `${fromFileName},${preferences.importModuleSpecifierEnding},${preferences.importModuleSpecifierPreference},${options.overrideImportMode}`;
+	}
+
+	function createInfo(
+		kind: ResolvedModuleSpecifierInfo["kind"] | undefined,
+		modulePaths: readonly ModulePath[] | undefined,
+		moduleSpecifiers: readonly string[] | undefined,
+        packageName: string | undefined,
+		isBlockedByPackageJsonDependencies: boolean | undefined,
+	): ResolvedModuleSpecifierInfo {
+		return { kind, modulePaths, moduleSpecifiers, packageName, isBlockedByPackageJsonDependencies };
+	}
+}

--- a/src/5_6/project.ts
+++ b/src/5_6/project.ts
@@ -1,0 +1,16 @@
+import type { LanguageService, LanguageServiceHost } from 'typescript/lib/tsserverlibrary';
+import { ProjectOptions } from '../5_0/project';
+import { createProject as _createProject } from '../5_3/project';
+import { createModuleSpecifierCache } from './moduleSpecifierCache';
+
+export function createProject(
+	ts: typeof import('typescript/lib/tsserverlibrary'),
+	host: LanguageServiceHost,
+	createLanguageService: (host: LanguageServiceHost) => LanguageService,
+	options: ProjectOptions
+) {
+	// @ts-expect-error
+	options.createModuleSpecifierCache = createModuleSpecifierCache;
+
+	return _createProject(ts, host, createLanguageService, options);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import _47 from './4_7';
 import _50 from './5_0';
 import _53 from './5_3';
 import _55 from './5_5';
+import _56 from './5_6';
 
 export { PackageJsonAutoImportPreference } from './5_0/projectService';
 
@@ -19,6 +20,9 @@ export function createLanguageService(
 	setPreferences?(preferences: ts.UserPreferences): void;
 	projectUpdated?(updatedProjectDirectory: string): void;
 } {
+	if (semver.gte(ts.version, '5.6.1')) {
+		return _56(ts, sys, host, createLanguageService);
+	}
 	if (semver.gte(ts.version, '5.5.1')) {
 		return _55(ts, sys, host, createLanguageService);
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,9 @@ export function createLanguageService(
 	setPreferences?(preferences: ts.UserPreferences): void;
 	projectUpdated?(updatedProjectDirectory: string): void;
 } {
-	if (semver.gte(ts.version, '5.6.1')) {
+	// moduleSpecifierCache changes introduced in 5.6.1-rc 
+	// https://github.com/microsoft/TypeScript/pull/59604
+	if (semver.gte(ts.version, '5.6.1-rc')) {
 		return _56(ts, sys, host, createLanguageService);
 	}
 	if (semver.gte(ts.version, '5.5.1')) {


### PR DESCRIPTION
Porting changes to module specifier cache for typescript 5.6. Module specifier cache seems to change the most so I changed it to use the one in `ts.server` when possible, similar to `createSymlinkCache`. This should also work in the "typescript" import since it now includes the server namespace. So the port for 5.6 is mostly just a fallback. 