### PR TITLE
Bail on giant export maps

### DIFF
--- a/src/5_0/autoImportProviderProject.ts
+++ b/src/5_0/autoImportProviderProject.ts
@@ -162,6 +162,9 @@ export function createAutoImportProviderProjectStatic(
 					resolveJs,
 				);
 				if (entrypoints) {
+					// some packages have giant exports maps, don't add them to the project to not slow down the editor
+					if (entrypoints.length > 100) return;
+
 					const real = moduleResolutionHost.realpath?.(packageJson.packageDirectory);
 					const isSymlink = real && real !== packageJson.packageDirectory;
 					if (isSymlink) {


### PR DESCRIPTION
Some packages have a giant exports map, if we add them to the project it will slow down startup tremendously. Bail in this case and skip that dependency (similar how it already stops after too many dependencies)